### PR TITLE
[core] Check for VK_ESCAPE in loop and exit if found, async

### DIFF
--- a/01 - NDI Async Output/main.cpp
+++ b/01 - NDI Async Output/main.cpp
@@ -326,19 +326,15 @@ void WebcamApp::Run() {
 	BYTE* pScanline0 = nullptr;
 	LONG pitch;
 
-	//int index = 0;
-
 	while (true) {
 
 		streamIndex = 0;
 		flags = 0;
 		timestamp = 0;
 
-		// Control-C has no cleanup code and I need to exit, lol
-		//index++;
-		//if (index >= 10000) {
-		//	break;
-		//}
+		if (GetAsyncKeyState(VK_ESCAPE)) {
+			break;
+		}
 
 		HRESULT hr = sourceReader->ReadSample(MF_SOURCE_READER_FIRST_VIDEO_STREAM, 0, &streamIndex, &flags, &timestamp, sample.GetAddressOf());
 		if (FAILED(hr)) {

--- a/02 - DX11 Texture Output/main.cpp
+++ b/02 - DX11 Texture Output/main.cpp
@@ -337,8 +337,6 @@ void WebcamApp::Run() {
 	BYTE* pScanline0 = nullptr;
 	LONG pitch;
 
-	int index = 0;
-
 	GetSharedTextureHandle();
 
 	while (true) {
@@ -347,9 +345,7 @@ void WebcamApp::Run() {
 		flags = 0;
 		timestamp = 0;
 
-		// Control-C has no cleanup code and I need to exit, lol
-		index++;
-		if (index >= 1000) {
+		if (GetAsyncKeyState(VK_ESCAPE)) {
 			break;
 		}
 


### PR DESCRIPTION
I was using my loop counter debug code to exit most of the time -- I run like 5 seconds tests.

Now you can just hit escape like it should have been from the start.